### PR TITLE
feat(cmdRewrite): Implementation of args rewrite

### DIFF
--- a/examples/kvdb/main.go
+++ b/examples/kvdb/main.go
@@ -31,7 +31,6 @@ func main() {
 	conf.Snapshot = snapshot
 	conf.Restore = restore
 	conf.Tick = tick
-	conf.CmdRewriteFunc = cmdRewrite
 
 	conf.AddWriteCommand("set", cmdSET)
 	conf.AddWriteCommand("del", cmdDEL)
@@ -407,44 +406,6 @@ func restore(rd io.Reader) (interface{}, error) {
 		db.set(o)
 	}
 	return db, nil
-}
-
-func cmdRewrite(args [][]string) {
-	nowUnixTime := time.Now().Unix()
-
-	for i, arg := range args {
-		switch strings.ToLower(arg[0]) {
-		case "setex":
-			if len(arg) == 4 {
-				exDuration, err := strconv.ParseInt(arg[2], 10, 64)
-				if err == nil {
-					args[i] = []string{"setexat", arg[1], strconv.FormatInt(nowUnixTime+exDuration, 10), arg[3]}
-				}
-			}
-		case "expire":
-			if len(arg) == 3 {
-				exDuration, err := strconv.ParseInt(arg[2], 10, 64)
-				if err == nil {
-					args[i] = []string{"expireat", arg[1], strconv.FormatInt(nowUnixTime+exDuration, 10)}
-				}
-			}
-		case "lexpire":
-			if len(arg) == 3 {
-				exDuration, err := strconv.ParseInt(arg[2], 10, 64)
-				if err == nil {
-					args[i] = []string{"lexpireat", arg[1], strconv.FormatInt(nowUnixTime+exDuration, 10)}
-				}
-			}
-		case "hexpire":
-			if len(arg) == 3 {
-				exDuration, err := strconv.ParseInt(arg[2], 10, 64)
-				if err == nil {
-					args[i] = []string{"lexpireat", arg[1], strconv.FormatInt(nowUnixTime+exDuration, 10)}
-				}
-			}
-		default:
-		}
-	}
 }
 
 // #endregion -- SNAPSHOT & RESTORE


### PR DESCRIPTION
Hello, I am a contributor from gitsrc/IceFireDB.

When using uhaha, I found that some commands caused raft log rollback exceptions when combined with the underlying storage.

For example: setex xxx 100 xxx, when the program is restarted, the expiration time of the instruction is re-timed from the time it is started. I think it should be based on the previous time instead of restarting.

I think some instructions can be rewritten at the protocol analysis layer. I have helped you implement an instruction rewrite interface and implemented the cmdRewrite method in examples/kvdb/main.go.