### PR TITLE
gracefully shutdown and transfer leadership when before shutting down

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tidwall/uhaha
 
-go 1.15
+go 1.16
 
 require (
 	github.com/golang/snappy v0.0.3

--- a/uhaha.go
+++ b/uhaha.go
@@ -912,6 +912,23 @@ func joinClusterIfNeeded(conf Config, ra *raftWrap, addr net.Addr,
 		if found {
 			log.Noticef("ignoring join request because server already "+
 				"belongs to a cluster NodeID=\"%s\"", conf.NodeID)
+			return
+		}
+	} else {
+		// check same ID and Address in cluster
+		found := false
+		for _, s := range servers {
+			if string(s.ID) == conf.NodeID {
+				if string(s.Address) == addrStr {
+					found = true
+					break
+				}
+			}
+		}
+		if found {
+			log.Noticef("ignoring join request because server already "+
+				"belongs to a cluster NodeID=\"%s\"", conf.NodeID)
+			return
 		}
 	}
 

--- a/uhaha.go
+++ b/uhaha.go
@@ -1217,9 +1217,14 @@ func runAndWaitShutdown(wg *sync.WaitGroup, parent context.Context,
 		log.Errorf("failed to leave cluster %v", err)
 	}
 
-	if err := ra.Shutdown().Error(); err != nil {
-		log.Error("failed to raft shutdown %v", err)
+	// broadcast stop redis context
+	stop()
+
+	// stop listener.Listen
+	if err := svr.ln.Close(); err != nil {
+		log.Error(err)
 	}
+
 	log.Notice("server shutdown")
 }
 

--- a/uhaha_test.go
+++ b/uhaha_test.go
@@ -423,3 +423,400 @@ func TestLeaderAdvertise(t *testing.T) {
 		func() TestClusterContext { return newLeaderAdvertiseTestCluster() },
 	)
 }
+
+// Server shutdown signal test
+const slowresponse_app string = `
+package main
+
+import (
+	"github.com/tidwall/uhaha"
+	"time"
+	"os"
+	"syscall"
+)
+
+type data struct {
+	counter int
+}
+
+func main() {
+	var conf uhaha.Config
+	conf.Name = "slowresp"
+	conf.InitialData = new(data)
+	conf.AddWriteCommand("incre", cmdINCRE)
+	conf.ServerShutdownSignals = []os.Signal{syscall.SIGUSR1}
+	conf.LeadershipTransferSignals = []os.Signal{syscall.SIGCONT}
+	uhaha.Main(conf)
+}
+
+func cmdINCRE(m uhaha.Machine, args []string) (interface{}, error) {
+	data := m.Data().(*data)
+	data.counter += 1
+	time.Sleep(time.Second * 5)
+	return data.counter, nil
+}
+`
+
+func buildSlowResponseApp(t *testing.T) {
+	temp, err := ioutil.TempFile("", "testslowapp*.go")
+	if err != nil {
+		wlog("::BUILD::FAIL::\n%s\n", err.Error())
+		badnews()
+	}
+	if _, err := temp.WriteString(slowresponse_app); err != nil {
+		wlog("::BUILD::FAIL::\n%s\n", err.Error())
+		badnews()
+	}
+	temp.Close()
+
+	t.Cleanup(func() {
+		os.Remove(temp.Name())
+	})
+
+	run("go", "build", "-o",
+		filepath.Join("testing", app), temp.Name())
+
+	wlog("::BUILD::Ok\n")
+}
+
+func testSlowResponseClusters(t *testing.T, sizes []int, numClients int,
+	newCtx func() TestClusterContext,
+) {
+	genSeed()
+	must(nil, os.MkdirAll("testing", 0777))
+	verifyGoVersion()
+	buildSlowResponseApp(t)
+	for _, size := range sizes {
+		t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
+			testSingleCluster(size, newCtx(), numClients)
+		})
+	}
+}
+
+type gracefullyShutdownCluster struct {
+	mu    sync.Mutex
+	pids  []int
+	incre int
+}
+
+func newGracefullyShutdownCluster() *gracefullyShutdownCluster {
+	return &gracefullyShutdownCluster{}
+}
+
+func (ctx *gracefullyShutdownCluster) Start(size, numClients int, insts []*Instance) {
+	pids := make([]int, len(insts))
+	for i, ins := range insts {
+		pids[i] = ins.PID()
+	}
+
+	wlog(
+		"::CLUSTER::Run %d servers (GracefullyShutdown) pid=%v",
+		size,
+		pids,
+	)
+	ctx.mu.Lock()
+	ctx.pids = pids
+	ctx.mu.Unlock()
+}
+
+func (ctx *gracefullyShutdownCluster) Monitor(size int) {
+	time.Sleep(time.Second)
+
+	numKillServer := size / 2
+	killPids := make([]int, 0, numKillServer)
+	for i := 0; i < numKillServer; i += 1 {
+		ctx.mu.Lock()
+		pid := ctx.pids[0]
+		ctx.pids = ctx.pids[1:]
+		ctx.mu.Unlock()
+
+		p, err := os.FindProcess(pid)
+		if err != nil {
+			wlog("::CLUSTER::Process %d not found(%s)", pid, err.Error())
+			badnews()
+		}
+		defer p.Release()
+
+		if err := p.Signal(syscall.SIGUSR1); err != nil {
+			wlog("::CLUSTER::Process %d signal err=%s", pid, err.Error())
+			badnews()
+		}
+
+		wlog("::CLUSTER::Process %d sent signal", pid)
+		killPids = append(killPids, pid)
+	}
+}
+
+func (ctx *gracefullyShutdownCluster) ExecClient(size int, clientNum int, c *TestConn) {
+	start := time.Now()
+	reply, err := redis.Int(c.Do("INCRE"), nil)
+	if err != nil {
+		wlog("::CLIENT::Error %s", err.Error())
+		badnews()
+	}
+	wlog("::CLIENT::slowreq reply=%d elapse=%s", reply, time.Since(start))
+
+	ctx.mu.Lock()
+	ctx.incre += 1
+	ctx.mu.Unlock()
+}
+
+type shutdownSignalRemoveServerCluster struct {
+	pids []int
+}
+
+func newShutdownSignalRemoveServerCluster() *shutdownSignalRemoveServerCluster {
+	return &shutdownSignalRemoveServerCluster{}
+}
+
+func (ctx *shutdownSignalRemoveServerCluster) Start(size, numClients int, insts []*Instance) {
+	pids := make([]int, len(insts))
+	for i, ins := range insts {
+		pids[i] = ins.PID()
+	}
+
+	wlog(
+		"::CLUSTER::Run %d servers (ShutdownSignalRemoveServer) pid=%v",
+		size,
+		pids,
+	)
+
+	ctx.pids = pids
+}
+
+func (ctx *shutdownSignalRemoveServerCluster) Monitor(size int) {
+	conns := make([]redis.Conn, size)
+	for i := 0; i < size; i += 1 {
+		addr := fmt.Sprintf(":3300%d", i+1)
+		conn, err := redis.Dial("tcp", addr)
+		if err != nil {
+			wlog("::CLIENT::DialError %s", err)
+			badnews()
+		}
+		conns[i] = conn
+	}
+	defer func() {
+		for _, conn := range conns {
+			conn.Close()
+		}
+	}()
+
+	for _, conn := range conns {
+		reply, err := redis.String(conn.Do("PING"))
+		if err != nil {
+			wlog("::CLIENT::%s", err)
+			badnews()
+		}
+		if reply != "PONG" {
+			wlog("::CLIENT::Expected 'PONG' got '%s'", reply)
+			badnews()
+		}
+	}
+
+	checkServerList := func(clusterSize int) {
+		lastServerList := ""
+		for _, conn := range conns {
+			reply, err := conn.Do("RAFT", "SERVER", "LIST")
+			if err != nil {
+				wlog("::CLIENT::%s", err)
+				badnews()
+			}
+			replies, ok := reply.([]interface{})
+			if ok != true {
+				wlog("::CLIENT::RAFT_SERVER_LIST empty")
+				badnews()
+			}
+
+			list := make([]string, len(replies))
+			for i, r := range replies {
+				s, err := redis.Strings(r, nil)
+				if err != nil {
+					wlog("::CLIENT::%s", err)
+					badnews()
+				}
+				list[i] = strings.Join(s, " ")
+			}
+			current := strings.Join(list, ",")
+
+			if lastServerList == "" {
+				lastServerList = current
+			}
+			if lastServerList != current {
+				wlog(
+					"::CLIENT::RAFT_SERVER_LIST not same %s <> %s",
+					lastServerList,
+					current,
+				)
+				badnews()
+			}
+			if len(list) != clusterSize {
+				wlog(
+					"::CLUSTER::SIZE unexpected size: %d != %d",
+					clusterSize,
+					len(list),
+				)
+			}
+		}
+
+		wlog(
+			"::RAFT_SERVER_LIST current=%s",
+			lastServerList,
+		)
+	}
+
+	checkServerList(size)
+
+	pid := ctx.pids[0]
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		wlog("::CLUSTER::Process %d not found(%s)", pid, err.Error())
+		badnews()
+	}
+	defer p.Release()
+
+	if err := p.Signal(syscall.SIGUSR1); err != nil {
+		wlog("::CLUSTER::Process %d signal err=%s", pid, err.Error())
+		badnews()
+	}
+
+	conns = conns[1:]
+
+	// wait sync
+	time.Sleep(time.Second * 10)
+
+	checkServerList(size - 1)
+}
+
+func (ctx *shutdownSignalRemoveServerCluster) ExecClient(size int, clientNum int, c *TestConn) {
+}
+
+func TestServerShutdownSignal(t *testing.T) {
+	testSlowResponseClusters(t,
+		[]int{5, 3, 1},
+		10,
+		func() TestClusterContext { return newGracefullyShutdownCluster() },
+	)
+	testSlowResponseClusters(t,
+		[]int{5, 3},
+		10,
+		func() TestClusterContext { return newShutdownSignalRemoveServerCluster() },
+	)
+}
+
+type leaderTransferCluster struct {
+	pids []int
+}
+
+func newLeaderTransferCluster() *leaderTransferCluster {
+	return &leaderTransferCluster{}
+}
+
+func (ctx *leaderTransferCluster) Start(size, numClients int, insts []*Instance) {
+	pids := make([]int, len(insts))
+	for i, ins := range insts {
+		pids[i] = ins.PID()
+	}
+
+	wlog(
+		"::CLUSTER::Run %d servers (LeaderTransfer) pid=%v",
+		size,
+		pids,
+	)
+
+	ctx.pids = pids
+}
+
+func (ctx *leaderTransferCluster) Monitor(size int) {
+	conns := make([]redis.Conn, size)
+	for i := 0; i < size; i += 1 {
+		addr := fmt.Sprintf(":3300%d", i+1)
+		conn, err := redis.Dial("tcp", addr)
+		if err != nil {
+			wlog("::CLIENT::DialError %s", err)
+			badnews()
+		}
+		conns[i] = conn
+	}
+	defer func() {
+		for _, conn := range conns {
+			conn.Close()
+		}
+	}()
+
+	for _, conn := range conns {
+		reply, err := redis.String(conn.Do("PING"))
+		if err != nil {
+			wlog("::CLIENT::%s", err)
+			badnews()
+		}
+		if reply != "PONG" {
+			wlog("::CLIENT::Expected 'PONG' got '%s'", reply)
+			badnews()
+		}
+	}
+
+	checkLeader := func() string {
+		lastLeader := ""
+		for _, conn := range conns {
+			reply, err := redis.String(conn.Do("RAFT", "LEADER"))
+			if err != nil {
+				wlog("::CLIENT::%s", err)
+				badnews()
+			}
+			if lastLeader == "" {
+				lastLeader = reply
+			}
+
+			if lastLeader != reply {
+				wlog(
+					"::CLIENT::RAFT_LEADER not same %s <> %s",
+					lastLeader,
+					reply,
+				)
+				badnews()
+			}
+		}
+		wlog(
+			"::RAFT_LEADER current=%s",
+			lastLeader,
+		)
+		return lastLeader
+	}
+
+	leader1 := checkLeader()
+
+	for _, pid := range ctx.pids {
+		p, err := os.FindProcess(pid)
+		if err != nil {
+			wlog("::CLUSTER::Process %d not found(%s)", pid, err.Error())
+			badnews()
+		}
+		defer p.Release()
+
+		if err := p.Signal(syscall.SIGCONT); err != nil {
+			wlog("::CLUSTER::Process %d signal err=%s", pid, err.Error())
+			badnews()
+		}
+	}
+
+	// wait sync
+	time.Sleep(time.Second * 10)
+
+	leader2 := checkLeader()
+
+	if leader1 == leader2 {
+		wlog("::CLUSTER::LeadershipTransfer failed %s == %s", leader1, leader2)
+	}
+}
+
+func (ctx *leaderTransferCluster) ExecClient(size int, clientNum int, c *TestConn) {
+}
+
+// Server leader transfer  signal test
+func TestServerLeaderTransfer(t *testing.T) {
+	testSlowResponseClusters(t,
+		[]int{3, 5},
+		10,
+		func() TestClusterContext { return newLeaderTransferCluster() },
+	)
+}


### PR DESCRIPTION
### what do we want to fix?

1. to safely remove the server in case of server maintenance or predictive failure
2. when cluster removing a server, if it is configured as a leader, we want to transfer it and then terminate it.
3. to shutdown server gracefully with proper signal handling.
4. ip address of server changes dynamically by DHCP (including when restart), so we want to leave cluster when server is terminated.
5. we want to rejoin same cluster when server is restart for some reason, or when it comes back from maintenance.

### about this modification

- [Context.Done()](https://pkg.go.dev/context#Context) added as reference so that server can be stopped after all responses have been returned.
- to integrate with Supervisor systems(e.g. daemontools, docker), defined signals in `ServerShutdownSignals` to be able to shutdown server.
  by default, shutdown will be performed when `syscall.SIGINT` or `syscall.SIGTERM` signal is received.
- add `LeadershipTransferSignals` to Config so that leader node can be transferred leadership to [another node](https://pkg.go.dev/github.com/hashicorp/raft#Raft.LeadershipTransfer) in case of Leader node.
  by default, transfered when `SIGUSR2` signal is received.
  this can be used to safely shutdown server for maintenance.
- even when server shutdown, leader node will transfer leadership.
- if server shutdown, heartbeat will no longer needed, so server will shutdown after [RemoveServer](https://pkg.go.dev/github.com/hashicorp/raft#Raft.RemoveServer).
- internally, due to use of `RAFT SERVER REMOVE` command for leader node, the Context for signal handling and the Context for Redis management are separated.