### PR TITLE
automatically eject servers from Peer list if heartbeat failing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang/snappy v0.0.3
 	github.com/gomodule/redigo v1.8.4
 	github.com/hashicorp/go-hclog v0.16.1
-	github.com/hashicorp/raft v1.3.1
+	github.com/hashicorp/raft v1.3.2
 	github.com/hashicorp/raft-boltdb v0.0.0-20210422161416-485fa74b0b01
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/tidwall/match v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/raft v1.1.0/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
-github.com/hashicorp/raft v1.3.1 h1:zDT8ke8y2aP4wf9zPTB2uSIeavJ3Hx/ceY4jxI2JxuY=
-github.com/hashicorp/raft v1.3.1/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
+github.com/hashicorp/raft v1.3.2 h1:j2tqHqFnDdWCepLxzuo3b6WzS2krIweBrvEoqBbWMTo=
+github.com/hashicorp/raft v1.3.2/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
 github.com/hashicorp/raft-boltdb v0.0.0-20210422161416-485fa74b0b01 h1:EfDtu7qY4bD9hNY9sIryn1L/Ycvo+/WPEFT2Crwdclg=
 github.com/hashicorp/raft-boltdb v0.0.0-20210422161416-485fa74b0b01/go.mod h1:L6EUYfWjwPIkX9uqJBsGb3fppuOcRx3t7z2joJnIf/g=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=

--- a/uhaha.go
+++ b/uhaha.go
@@ -1160,10 +1160,6 @@ func heartbeatReadLoop(ra *raftWrap, ch chan raft.Observation) {
 }
 
 func runAutoEject(conf Config, ra *raftWrap, log *redlog.Logger) {
-	if ra.advertise == "" {
-		return
-	}
-
 	lastStateLeader := false
 	for {
 		time.Sleep(time.Second)

--- a/uhaha_test.go
+++ b/uhaha_test.go
@@ -2,6 +2,7 @@ package uhaha
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -416,5 +417,202 @@ func TestLeaderAdvertise(t *testing.T) {
 		[]int{1, 3, 5}, // sizes
 		50,             // clients
 		func() TestClusterContext { return newLeaderAdvertiseTestCluster() },
+	)
+}
+
+// AUTO EJECT TEST
+
+const autoeject_app string = `
+package main
+
+import (
+	"github.com/tidwall/uhaha"
+	"time"
+)
+
+func main() {
+	var conf uhaha.Config
+	conf.Name = "autoejectapp"
+	conf.InitialData = struct{}{}
+	conf.AutoEjectServers = true
+	conf.ServerFailureLimit = 3
+	conf.ServerContactTimeout = 10 * time.Second
+	uhaha.Main(conf)
+}
+`
+
+func buildAutoEjectEnabledApp(t *testing.T) {
+	temp, err := ioutil.TempFile("", "testautoejectapp*.go")
+	if err != nil {
+		wlog("::BUILD::FAIL::\n%s\n", err.Error())
+		badnews()
+	}
+	if _, err := temp.WriteString(autoeject_app); err != nil {
+		wlog("::BUILD::FAIL::\n%s\n", err.Error())
+		badnews()
+	}
+	temp.Close()
+
+	t.Cleanup(func() {
+		os.Remove(temp.Name())
+	})
+
+	run("go", "build", "-o", filepath.Join("testing", app), temp.Name())
+
+	wlog("::BUILD::Ok\n")
+}
+
+func testAutoEjectClusters(t *testing.T, sizes []int, numClients int,
+	newCtx func() TestClusterContext,
+) {
+	genSeed()
+	must(nil, os.MkdirAll("testing", 0777))
+	verifyGoVersion()
+	buildAutoEjectEnabledApp(t)
+	for _, size := range sizes {
+		t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
+			testSingleCluster(size, newCtx(), numClients)
+		})
+	}
+}
+
+type autoEjectTestCluster struct{}
+
+func newAutoEjectTestCluster() *autoEjectTestCluster {
+	return &autoEjectTestCluster{}
+}
+
+func (ctx *autoEjectTestCluster) Start(size int, numClients int) {
+}
+
+func (ctx *autoEjectTestCluster) Monitor(size int) {
+	conns := make([]redis.Conn, size)
+	for i := 0; i < size; i += 1 {
+		conn, err := redis.Dial("tcp", fmt.Sprintf(":3300%d", i+1))
+		if err != nil {
+			wlog("::CLIENT::Error %s", err.Error())
+			badnews()
+		}
+		conns[i] = conn
+	}
+	defer func() {
+		for _, conn := range conns {
+			conn.Close()
+		}
+	}()
+
+	for _, conn := range conns {
+		reply, err := redis.String(conn.Do("PING"))
+		if err != nil {
+			wlog("::CLIENT::%s", err)
+			badnews()
+		}
+		if reply != "PONG" {
+			wlog("::CLIENT::Expected 'PONG' got '%s'", reply)
+			badnews()
+		}
+	}
+
+	getServerAddresses := func() string {
+		serverlist := ""
+		for _, conn := range conns {
+			reply, err := conn.Do("RAFT", "SERVER", "LIST")
+			if err != nil {
+				wlog("::CLIENT::%s", err)
+				badnews()
+			}
+			addresses := make([]string, 0)
+			replies := reply.([]interface{})
+			for _, r := range replies {
+				s, _ := redis.Strings(r, nil)
+				for i := 0; i < len(s); i += 2 {
+					key, value := s[i], s[i+1]
+					if strings.ToLower(key) == "address" {
+						addresses = append(addresses, value)
+					}
+				}
+			}
+			curr := strings.Join(addresses, ",")
+
+			if serverlist == "" {
+				serverlist = curr
+			}
+			if serverlist != curr {
+				wlog(
+					"::CLIENT::RAFT_SERVER_LIST not same %s <> %s",
+					serverlist,
+					curr,
+				)
+				badnews()
+			}
+		}
+		return serverlist
+	}
+	grepConn := func(index int) []redis.Conn {
+		newConns := make([]redis.Conn, 0, len(conns)-1)
+		for i, conn := range conns {
+			if i != index {
+				newConns = append(newConns, conn)
+			}
+		}
+		return newConns
+	}
+
+	a1 := getServerAddresses()
+
+	// first node shutdown
+	r1 := rand.Int() % size
+	wlog("::SERVER::shutdown %d", r1)
+	if _, err := conns[r1].Do("shutdown"); err != nil {
+		if errors.Is(err, io.EOF) != true {
+			wlog("::CLIENT::%s", err)
+			badnews()
+		}
+	}
+	conns = grepConn(r1)
+
+	// wait ServerContactTimeout
+	time.Sleep(time.Second * 15)
+
+	a2 := getServerAddresses()
+
+	if a1 == a2 {
+		wlog("::SERVER::auto_eject failed same servers %s == %s", a1, a2)
+		badnews()
+	}
+	wlog("::SERVER list=%s", a2)
+
+	if 2 < (size - 1) {
+		// second node shutdown
+		r2 := rand.Int() % (size - 1)
+		wlog("::SERVER::shutdown %d", r2)
+		if _, err := conns[r2].Do("shutdown"); err != nil {
+			if errors.Is(err, io.EOF) != true {
+				wlog("::CLIENT::%s", err)
+				badnews()
+			}
+		}
+		conns = grepConn(r2)
+
+		// wait ServerContactTimeout
+		time.Sleep(time.Second * 15)
+
+		a3 := getServerAddresses()
+
+		if a2 == a3 {
+			wlog("::SERVER::auto_eject failed same servers %s == %s", a1, a2)
+			badnews()
+		}
+		wlog("::SERVER list=%s", a3)
+	}
+}
+
+func (ctx *autoEjectTestCluster) ExecClient(size int, n int, c *TestConn) {}
+
+func TestAutoEject(t *testing.T) {
+	testAutoEjectClusters(t,
+		[]int{3, 5},
+		10,
+		func() TestClusterContext { return newAutoEjectTestCluster() },
 	)
 }


### PR DESCRIPTION
### what do we want to fix?

1. when server is stopped for some reason,
   the orchestration/autoscaler system will rebuild a new server,
   so stopped node will be destroyed without being reused,
   and server that does not respond to heartbeats for a certain period of
   time should be removed from cluster
   (to reduce the manpower required for maintenance ops).
2. leader node will periodically check for failing servers and automatically remove them from cluster.

### about this modification

Using [Observer](https://pkg.go.dev/github.com/hashicorp/raft#Raft.RegisterObserver) to measure count of failures from FailedHeartbeatObservation.
`ServerFailureLimit` has been added to `Config` file and is used as a threshold for count of Heartbeat failures.
`ServerFailureLimit` is used as safeguard in case Node flapping will cause Node to leave cluster immediately.

If there are no updates for more than `ServerContactTimeout` compared to [LastContact](https://pkg.go.dev/github.com/hashicorp/raft#FailedHeartbeatObservation), leader node will execute [RemoveServer](https://pkg.go.dev/github.com/hashicorp/raft#Raft.RemoveServer).
`ServerFailureLimit` and `ServerContactTimeout` parameter, will automatically remove servers that are unable to communicate with network.

updated raft version(v1.3.1 to [v1.3.2](https://github.com/hashicorp/raft/releases/tag/v1.3.2)) to be able to get [FailedHeartbeatObservation](https://pkg.go.dev/github.com/hashicorp/raft#FailedHeartbeatObservation) and [ResumedHeartbeatObservation](https://pkg.go.dev/github.com/hashicorp/raft#ResumedHeartbeatObservation) from Observer.