### PR TITLE
Router Mode

### DIFF
--- a/uhaha.go
+++ b/uhaha.go
@@ -127,7 +127,9 @@ Router options:
                             WriteCommand will be forwarded to leader node, and
                             ReadCommand and other commands will be forwarded
                             to other nodes.
-                            Each node has connection pooling, so you can adjust
+                            also, if using ReadCommand to read from follower,
+                            enable --openreads.
+                            each node has connection pooling, so you can adjust
                             pool by specifying --router-pool-size and
                             --router-pool-max-size.
   --router-pool-max-size :  do not reuse pooled redis connections after the

--- a/uhaha.go
+++ b/uhaha.go
@@ -132,7 +132,7 @@ Router options:
   --router-pool-max-size :  do not reuse pooled redis connections after the
                             specified time. (default: 30s)
   --router-pool-size     :  size of redis connections pool for
-                            each node. (default: 3000)
+                            each node. (default: 500)
 `
 
 // Config is the configuration for managing the behavior of the application.
@@ -238,7 +238,7 @@ type Config struct {
 	InitRunQuit           bool          // default false
 	RouterMode            bool          // default false
 	RouterPoolMaxLifetime time.Duration // default 30s
-	RouterPoolSize        int           // default 3000
+	RouterPoolSize        int           // default 500
 }
 
 // The Backend database format used for storing Raft logs and meta data.
@@ -286,7 +286,7 @@ func (conf *Config) def() {
 		conf.RouterPoolMaxLifetime = time.Second * 30
 	}
 	if conf.RouterPoolSize == 0 {
-		conf.RouterPoolSize = 3000
+		conf.RouterPoolSize = 500
 	}
 }
 

--- a/uhaha.go
+++ b/uhaha.go
@@ -3447,9 +3447,14 @@ func (s *routeService) Send(args []string, opts *SendOptions) Receiver {
 		start := time.Now()
 		resp, err := s.execWrite(cmd, args)
 		return Response(resp, time.Since(start), errRaftConvert(s.ra, err))
-	case 'r', 's':
+	case 'r':
 		start := time.Now()
 		resp, err := s.execRead(cmd, args)
+		return Response(resp, time.Since(start), errRaftConvert(s.ra, err))
+	case 's':
+		start := time.Now()
+		pm := intermediateMachine{m: s.m, context: opts.Context}
+		resp, err := cmd.fn(pm, s.ra, args)
 		return Response(resp, time.Since(start), errRaftConvert(s.ra, err))
 	default:
 		return Response(nil, 0, errors.New("invalid request"))

--- a/uhaha_test.go
+++ b/uhaha_test.go
@@ -93,6 +93,8 @@ type instance struct {
 	cmd  *exec.Cmd
 }
 
+var appendArgs = []string{}
+
 func startInstance(num, size int, wg *sync.WaitGroup) *instance {
 	output := os.Getenv("OUTPUT_LOGS") != ""
 	inst := &instance{num: num, size: size}
@@ -103,10 +105,12 @@ func startInstance(num, size int, wg *sync.WaitGroup) *instance {
 	}
 	inst.path = path
 	appPath := must(filepath.Abs(filepath.Join("testing", app))).(string)
-	inst.cmd = exec.Command(appPath,
+	args := []string{
 		"-t", fmt.Sprintf("%d", num),
 		"-a", ":33000",
-	)
+	}
+	args = append(args, appendArgs...)
+	inst.cmd = exec.Command(appPath, args...)
 	inst.cmd.Dir = path
 	rerr := must(inst.cmd.StderrPipe()).(io.ReadCloser)
 	rout := must(inst.cmd.StdoutPipe()).(io.ReadCloser)
@@ -221,6 +225,7 @@ func testSingleCluster(size int, ctx TestClusterContext, numClients int) {
 type TestConn struct {
 	conn redis.Conn
 	size int
+	addr string
 }
 
 func OpenTestConn(size int) *TestConn {
@@ -228,6 +233,7 @@ func OpenTestConn(size int) *TestConn {
 	start := time.Now()
 	for {
 		addr := fmt.Sprintf(":3300%d", (rand.Int()%size)+1)
+		c.addr = addr
 		var err error
 		c.conn, err = redis.Dial("tcp", addr)
 		if err == nil {
@@ -416,5 +422,149 @@ func TestLeaderAdvertise(t *testing.T) {
 		[]int{1, 3, 5}, // sizes
 		50,             // clients
 		func() TestClusterContext { return newLeaderAdvertiseTestCluster() },
+	)
+}
+
+// ROUTER TEST
+
+type routerTestCluster struct {
+}
+
+func newRouterTestCluster() *routerTestCluster {
+	return &routerTestCluster{}
+}
+
+func (ctx *routerTestCluster) Start(size int, numClients int) {
+	wlog("::CLUSTER::Run %d clients (RouterTest)", numClients)
+}
+
+func (ctx *routerTestCluster) Monitor(size int) {
+	// run router
+	pid := startRouterInstance()
+	defer func() {
+		p, err := os.FindProcess(pid)
+		if err != nil {
+			panic(err.Error())
+		}
+		defer p.Release()
+		p.Kill()
+	}()
+
+	conn, err := redis.Dial("tcp", ":23001")
+	if err == nil {
+		reply, e := redis.String(conn.Do("PING"))
+		if e == nil {
+			if reply != "PONG" {
+				wlog("::CLIENT::Expected 'PONG' got '%s'", reply)
+				badnews()
+			}
+		}
+	}
+	time.Sleep(time.Second * 3)
+	ctx.ExecRouter(1, &TestConn{conn: conn, size: 1, addr: ":23001"})
+}
+
+func (ctx *routerTestCluster) ExecClient(size int, clientNum int,
+	c *TestConn,
+) {
+	// check follower node
+	if strings.HasSuffix(c.addr, ":33001") != true {
+		_, err := c.conn.Do("SET", "foo"+strconv.Itoa(clientNum), "test")
+		if err == nil {
+			panic("expect '(error) MOVED 0 0.0.0.0:33001'")
+		}
+		if strings.HasPrefix(err.Error(), "MOVED ") != true {
+			panic("expect '(error) MOVED 0 0.0.0.0:33001'")
+		}
+	}
+}
+
+func (ctx *routerTestCluster) ExecRouter(clientNum int, c *TestConn) {
+	// router node
+	outSET, err := redis.String(c.conn.Do("SET", "foo"+strconv.Itoa(clientNum), "test"))
+	if err != nil {
+		panic(err.Error())
+	}
+	if outSET != "OK" {
+		panic(fmt.Sprintf("mismatch: got '%s', expected 'OK'", outSET))
+	}
+
+	time.Sleep(time.Millisecond * 100) // wait replication
+
+	outGET, err := redis.String(c.conn.Do("GET", "foo"+strconv.Itoa(clientNum)))
+	if err != nil {
+		panic(err.Error())
+	}
+	if outGET != "test" {
+		panic(fmt.Sprintf("mismatch: got '%s', expected 'test'", outGET))
+	}
+}
+
+func startRouterInstance() int {
+	path, err := ioutil.TempDir("", "")
+	if err != nil {
+		panic(err)
+	}
+	appPath := must(filepath.Abs(filepath.Join("testing", app))).(string)
+	cmd := exec.Command(appPath,
+		"-j", ":33001",
+		"-n", "r0001",
+		"-a", ":23001",
+		"--router",
+	)
+	cmd.Dir = path
+	rerr := must(cmd.StderrPipe()).(io.ReadCloser)
+	rout := must(cmd.StdoutPipe()).(io.ReadCloser)
+	in := must(cmd.StdinPipe()).(io.WriteCloser)
+	rd := io.MultiReader(rerr, rout)
+	must(nil, cmd.Start())
+	readyCh := make(chan bool, 2)
+	go func() {
+		defer func() {
+			rerr.Close()
+			rout.Close()
+			in.Close()
+			cmd.Wait()
+		}()
+		brd := bufio.NewReader(rd)
+		for {
+			line, err := brd.ReadString('\n')
+			if err != nil {
+				wlog("::ROUTERINST::ERROR::%s", err)
+				badnews()
+			}
+			line = strings.TrimSpace(line)
+			if strings.Contains(line, "logs loaded: ready for commands") {
+				readyCh <- true
+				io.Copy(ioutil.Discard, brd)
+				break
+			}
+		}
+	}()
+	ready := false
+	tick := time.NewTicker(time.Second * 10)
+	for !ready {
+		select {
+		case <-readyCh:
+			ready = true
+		case <-tick.C:
+			wlog("::ROUTERINST::TIMEOUT")
+			badnews()
+		}
+	}
+	wlog("::ROUTERINST::Started")
+	return cmd.Process.Pid
+}
+
+func TestRouter(t *testing.T) {
+	t.Cleanup(func() {
+		appendArgs = []string{}
+	})
+	appendArgs = []string{"--openreads"}
+
+	testClusters(t,
+		[]int{5},
+		10,
+		func() TestClusterContext { return newRouterTestCluster() },
 	)
 }


### PR DESCRIPTION
I was created `Router Mode`, inspired by [MySQL Router](https://www.mysql.com/products/enterprise/router.html).

`Router Mode` enabled server will determine WriteCommand/ReadCommand and forward command to nodes in cluster.
the connections to each node are connection pooling, which will serve to distribute ReadCommand workload (use `--openreads` command with it).
changes in number of nodes can be made periodically or using [raft.Observation](https://pkg.go.dev/github.com/hashicorp/raft#Raft.RegisterObserver) to keep node list updated.

The difference between `Router Mode` and [redis cluster command](https://github.com/tidwall/uhaha/issues/1) is that the client does not need to manage the nodes to be connected to, and it is easy to deploy under a load balancer.

![uhaha_router_3](https://user-images.githubusercontent.com/42143893/148160040-0538185c-6c15-4f69-b543-30a2496dfebd.jpg)